### PR TITLE
Remove Duplicate Fallback Source

### DIFF
--- a/core/ip/fallbacks.go
+++ b/core/ip/fallbacks.go
@@ -30,9 +30,9 @@ import (
 // IPFallbackAddresses represents the various services we can use to fetch our public IP.
 var IPFallbackAddresses = []string{
 	"https://api.ipify.org",
+	"https://api.ipquery.io",
 	"https://ip2location.io/ip",
 	"https://ipinfo.io/ip",
-	"https://api.ipify.org",
 	"https://ifconfig.me",
 	"https://www.trackip.net/ip",
 	"https://checkip.amazonaws.com/",


### PR DESCRIPTION
api.ipify.org was mentioned twice in fallback sources. Removed the duplicate and added another api.